### PR TITLE
Add privacy policy snippets for core commenting and embeds

### DIFF
--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -8,6 +8,7 @@ Cut and paste-able snippets that describe how core collects, manages and shares 
 at all (e.g. visitors)
 * Gravatar: An optional public profile, including a photo or image, related to your email address.
 * IP Address: The address of your device on the Internet.  This address is assigned by the Internet Service Provider providing the connection to the Internet which your device is using and may be shared with other devices at that same location.
+* Role: A logged in user also has a role, e.g. Contributor, Author, Editor, etc. Each role has a prescribed set of capabilities - e.g. some roles can delete comments but others cannot.
 * User Agent: A browser’s user agent is a line of text that usually includes which browser you are using, its version, and your operating system and its version.
 
 ## Comments
@@ -23,6 +24,11 @@ at all (e.g. visitors)
   * shared with the Akismet service to determine whether or not your comment is spam. The Akismet service privacy policy is available here: https://automattic.com/privacy/
   * stored in the website’s database, access to which is restricted to site administrators. Site administrator authentication is by username and password.
   * retained indefinitely until explicitly deleted by an administrator.
+
+### Comments Left by Logged In Users
+
+* You may edit the display name used for new comments in your profile.
+* If your role on the site has sufficient permission (e.g. Editor), you may edit or delete comments.
 
 ### Comments Left by Logged Out Users / Visitors
 

--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -69,7 +69,7 @@ Copy and paste-able snippets that describe how core collects, manages and shares
   * TED https://www.ted.com/about/our-organization/our-policies-terms/privacy-policy
   * Tumblr https://www.tumblr.com/policy/en/privacy
   * Twitter https://twitter.com/en/privacy
-  * VideoPress http://videopress.org/privacy-policy/
+  * VideoPress https://automattic.com/privacy/
   * Vimeo https://vimeo.com/privacy
   * Vine https://vine.co/privacy
   * WordPress Plugin Directory https://wordpress.org/about/privacy/

--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -14,7 +14,7 @@ at all (e.g. visitors)
 
 ### Comments Left by All Users
 
-* If you are logged in to the site and elect to leave a comment on a post, in addition to the comment text we also collect your IP Address and your User Agent.
+* If you elect to leave a comment on a post, in addition to the comment text you provide we also collect your IP Address and your User Agent.
 * Your comment text, your name, email address, website URL, IP Address and User Agent are accessible by administrators on our site.
 * A hash of your email address is provided to the Gravatar service to see if a profile picture of you is available for display. The Gravatar service privacy policy is available here: https://automattic.com/privacy/ Prior to approval of your comment, your profile picture is only visible to administrators. After approval of your comment, your profile picture is visible to the public in the context of your comment.
 * Following approval of your comment, your comment text, your name, and website URL (if provided) are visible to the public.

--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -1,11 +1,10 @@
 # Privacy Policy Snippets
 
-Cut and paste-able snippets that describe how core collects, manages and shares data provided by site users and visitors.
+Copy and paste-able snippets that describe how core collects, manages and shares data provided by site users and visitors.
 
 ## Definitions
 
-* Logged In vs Logged Out Users: Logged in users are users who have registered (created) an account on the site and have provided their username and password to log in to the site. Some sites require users to be registered and logged in to do things like comment on a post. Logged out users are users who have not logged in, or who do not have an account on the site
-at all (e.g. visitors)
+* Logged In vs Logged Out Users: Logged in users are users who have registered (created) an account on the site and have provided their username and password to log in to the site. Some sites require users to be registered and logged in to do things like comment on an article. Logged out users are users who have not logged in, or who do not have an account on the site at all (e.g. visitors).
 * Gravatar: An optional public profile, including a photo or image, related to your email address.
 * IP Address: The address of your device on the Internet.  This address is assigned by the Internet Service Provider providing the connection to the Internet which your device is using and may be shared with other devices at that same location.
 * Role: A logged in user also has a role, e.g. Contributor, Author, Editor, etc. Each role has a prescribed set of capabilities - e.g. some roles can delete comments but others cannot.
@@ -15,11 +14,11 @@ at all (e.g. visitors)
 
 ### Comments Left by All Users
 
-* If you elect to leave a comment on a post, in addition to the comment text you provide we also collect your IP Address and your User Agent.
+* If you elect to leave a comment on an article, in addition to the comment text you provide we also collect your IP Address and your User Agent.
 * Your comment text, your name, email address, website URL, IP Address and User Agent are accessible by administrators on our site.
-* A hash of your email address is provided to the Gravatar service to see if a profile picture of you is available for display. The Gravatar service privacy policy is available here: https://automattic.com/privacy/ Prior to approval of your comment, your profile picture is only visible to administrators. After approval of your comment, your profile picture is visible to the public in the context of your comment.
+* An anonymized string created from your email address (also called a hash) is provided to the Gravatar service to see if a profile picture of you is available for display. The Gravatar service privacy policy is available here: https://automattic.com/privacy/ Prior to approval of your comment, your profile picture is only visible to administrators. After approval of your comment, your profile picture is visible to the public in the context of your comment.
 * Following approval of your comment, your comment text, your name, and website URL (if provided) are visible to the public.
-* Comments containing links or certain words or phrases may require manual approval by an administrator
+* Comments containing links or certain words or phrases may require manual approval by an administrator.
 * Your comment, including comment text, your name, email address, website URL, IP address and User Agent, is:
   * shared with the Akismet service to determine whether or not your comment is spam. The Akismet service privacy policy is available here: https://automattic.com/privacy/
   * stored in the website’s database, access to which is restricted to site administrators. Site administrator authentication is by username and password.
@@ -32,5 +31,5 @@ at all (e.g. visitors)
 
 ### Comments Left by Logged Out Users / Visitors
 
-* If you are not logged in to the site and elect to leave a comment on a post, we require your name and your email address and we request your website URL. You may also elect to provide a partial name, initials or even a pseudonym in lieu of your full name. You are not required to provide a website URL.
+* If you are not logged in to the site and elect to leave a comment on an article, we require your name and your email address and we request your website URL. You may also elect to provide a partial name, initials or even a pseudonym in lieu of your full name. You are not required to provide a website URL.
 * When you leave a comment, you will be asked if you opt-in to saving your name, email address and website URL in your browser for future commenting. If you so opt-in, we store three cookies on your browser to make it easier for you to comment again in the future. The cookies contain your name, your email address and your website URL. They are set to expire after one year.

--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -33,3 +33,45 @@ Copy and paste-able snippets that describe how core collects, manages and shares
 
 * If you are not logged in to the site and elect to leave a comment on an article, we require your name and your email address and we request your website URL. You may also elect to provide a partial name, initials or even a pseudonym in lieu of your full name. You are not required to provide a website URL.
 * When you leave a comment, you will be asked if you opt-in to saving your name, email address and website URL in your browser for future commenting. If you so opt-in, we store three cookies on your browser to make it easier for you to comment again in the future. The cookies contain your name, your email address and your website URL. They are set to expire after one year.
+
+## Embedded Content
+
+* Articles on this site may include embedded content from other services (e.g. videos, images, articles, etc.).
+* These services may collect your IP address, your User Agent, store and retrieve cookies on your browser, embed additional third party tracking, and monitor your interaction with that embedded content, including correlating your interaction with the content with your account with that service, if you are logged in to that service.
+* A link to each service's privacy policy has been included below. Where a general privacy policy is not available, the applicable country is indicated.
+
+  * Amazon https://www.amazon.com/gp/help/customer/display.html?nodeId=468496
+  * Animoto https://animoto.com/legal/privacy_policy
+  * Blip https://blip.fm/corp/privacy
+  * CollegeHumor http://www.collegehumor.com/static/privacy/policy
+  * DailyMotion https://www.dailymotion.com/legal/privacy
+  * Facebook https://www.facebook.com/about/privacy
+  * Flickr https://policies.yahoo.com/privacy/flickr/
+  * FunnyOrDie.com http://www.funnyordie.com/about/privacy
+  * Hulu https://www.hulu.com/privacy
+  * Imgur https://imgur.com/privacy
+  * Instagram https://help.instagram.com/155833707900388
+  * Issuu https://issuu.com/legal/privacy
+  * Kickstarter https://www.kickstarter.com/privacy
+  * Meetup.com https://www.meetup.com/privacy/
+  * Mixcloud https://www.mixcloud.com/terms/
+  * Photobucket http://photobucket.com/privacy
+  * PollDaddy https://polldaddy.com/privacy/
+  * Reddit https://www.reddit.com/help/privacypolicy
+  * ReverbNation https://www.reverbnation.com/privacy
+  * Scribd (US) https://support.scribd.com/hc/en-us/articles/210129366-Privacy-policy
+  * SlideShare (LinkedIn) https://www.linkedin.com/legal/privacy-policy
+  * SmugMug https://www.smugmug.com/about/privacy/
+  * Someecards https://www.someecards.com/page/privacy
+  * SoundCloud https://soundcloud.com/pages/privacy
+  * Speaker Deck https://speakerdeck.com/privacy
+  * Spotify (US) https://www.spotify.com/us/legal/privacy-policy/
+  * TED https://www.ted.com/about/our-organization/our-policies-terms/privacy-policy
+  * Tumblr https://www.tumblr.com/policy/en/privacy
+  * Twitter https://twitter.com/en/privacy
+  * VideoPress http://videopress.org/privacy-policy/
+  * Vimeo https://vimeo.com/privacy
+  * Vine https://vine.co/privacy
+  * WordPress Plugin Directory https://wordpress.org/about/privacy/
+  * WordPress.tv https://wordpress.org/about/privacy/
+  * YouTube (Google) https://policies.google.com/privacy

--- a/Privacy-policy-snippets.md
+++ b/Privacy-policy-snippets.md
@@ -1,0 +1,30 @@
+# Privacy Policy Snippets
+
+Cut and paste-able snippets that describe how core collects, manages and shares data provided by site users and visitors.
+
+## Definitions
+
+* Logged In vs Logged Out Users: Logged in users are users who have registered (created) an account on the site and have provided their username and password to log in to the site. Some sites require users to be registered and logged in to do things like comment on a post. Logged out users are users who have not logged in, or who do not have an account on the site
+at all (e.g. visitors)
+* Gravatar: An optional public profile, including a photo or image, related to your email address.
+* IP Address: The address of your device on the Internet.  This address is assigned by the Internet Service Provider providing the connection to the Internet which your device is using and may be shared with other devices at that same location.
+* User Agent: A browser’s user agent is a line of text that usually includes which browser you are using, its version, and your operating system and its version.
+
+## Comments
+
+### Comments Left by All Users
+
+* If you are logged in to the site and elect to leave a comment on a post, in addition to the comment text we also collect your IP Address and your User Agent.
+* Your comment text, your name, email address, website URL, IP Address and User Agent are accessible by administrators on our site.
+* A hash of your email address is provided to the Gravatar service to see if a profile picture of you is available for display. The Gravatar service privacy policy is available here: https://automattic.com/privacy/ Prior to approval of your comment, your profile picture is only visible to administrators. After approval of your comment, your profile picture is visible to the public in the context of your comment.
+* Following approval of your comment, your comment text, your name, and website URL (if provided) are visible to the public.
+* Comments containing links or certain words or phrases may require manual approval by an administrator
+* Your comment, including comment text, your name, email address, website URL, IP address and User Agent, is:
+  * shared with the Akismet service to determine whether or not your comment is spam. The Akismet service privacy policy is available here: https://automattic.com/privacy/
+  * stored in the website’s database, access to which is restricted to site administrators. Site administrator authentication is by username and password.
+  * retained indefinitely until explicitly deleted by an administrator.
+
+### Comments Left by Logged Out Users / Visitors
+
+* If you are not logged in to the site and elect to leave a comment on a post, we require your name and your email address and we request your website URL. You may also elect to provide a partial name, initials or even a pseudonym in lieu of your full name. You are not required to provide a website URL.
+* When you leave a comment, you will be asked if you opt-in to saving your name, email address and website URL in your browser for future commenting. If you so opt-in, we store three cookies on your browser to make it easier for you to comment again in the future. The cookies contain your name, your email address and your website URL. They are set to expire after one year.

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ The following goals are identified:
    * To anonymise/delete personal data
    * To show/export personal data (for transfer)
    * Add notices for both registered users and commenters on what data is collected in core by default, and why.
-  
+
 1. Setup a privacy centre to hold GDPR information for site users, for site administrators, and developers.
 
    * For site users and administrators: What is collected, how long, why, etc
    * For developers: How to use the core tools
-   
+
 ## Roadmap
 The roadmap can be found in [this document](./Roadmap.md).
 ## Knowledge Base
 See the separate document for [the knowledge base](./KB.md).
+## Privacy Policy Snippets
+See the separate document for [cut and paste-able snippets for a site's privacy policy](./Privacy-policy-snippets.md).
 ## Cookies
 See the separate document [about Cookies](./Cookies.md) created by @pento and @clickysteve.
 ## Synched info
@@ -27,4 +29,3 @@ See the separate document for the [synched info](./Synched-info.md) created by @
 A separate document is created with [useful links](./Useful-links.md).
 ## Trac Tickets
 We could keep a list updated with [Trac tickets](./Trac-Tickets.md).
-


### PR DESCRIPTION
Would love feedback on this, especially any way to make it shorter since this is only one aspect of the privacy policy that sites (that enable commenting) will need.

Ideally the site owner (or builder) would cut and paste and edit snippets from this to create their privacy policy for their site (or their client's site).

Also be on the lookout for any dev-speak/jargon/legal-ese - ideally we use as plain English as possible here to make comprehension (and translation) easier for the end users.